### PR TITLE
feat(options) make the tslint options configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,43 @@ module.exports = {
 ```bash
 yarn jest
 ```
+
+## Options
+
+This project uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig), so you can provide config via:
+* a `jest-runner-tslint` property in your `package.json`
+* a `jest-runner-tslint.config.js` JS file
+* a `.jest-runner-tslintrc` JSON file
+
+
+In `package.json`
+```json
+{
+  "jest-runner-tslint": {
+    "cliOptions": {
+      // Options here
+    }
+  }
+}
+```
+
+or in `jest-runner-tslint.config.js`
+```js
+module.exports = {
+  cliOptions: {
+    // Options here
+  }
+}
+```
+
+
+### cliOptions
+
+jest-runner-tslint maps a lot of ESLint CLI arguments to config options. For example `--fix` is `cliOptions.fix`
+
+| option              | default     | example                                                                                     |
+|---------------------|-------------|---------------------------------------------------------------------------------------------|
+| fix                 | `false`     | `"fix": true`                                                                               |
+| formatter           | `"stylish"` | `"formatter": "tap"`                                                                        |
+| formattersDirectory | `null`      | `"formattersDirectory": "node_modules/custom-tslint-formatters/formatters"`                 |
+| rulesDirectory      | `null`      | `"rulesDirectory": "path/to/rules" or "rulesDirectory": ["path/to/rules", "path/to/other"]` |

--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
   "release": {
     "verifyConditions": "@semantic-release/github"
   },
+  "jest-runner-tslint": {
+    "cliOptions": {
+      "fix": true
+    }
+  },
   "devDependencies": {
     "@commitlint/cli": "6.0.2",
     "@commitlint/config-conventional": "6.0.2",
@@ -38,6 +43,7 @@
     "typescript": "2.6.2"
   },
   "dependencies": {
+    "cosmiconfig": "^3.1.0",
     "create-jest-runner": "^0.1.1",
     "tslint": "^5.8.0"
   }

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,12 +1,10 @@
 import * as fs from "fs";
 import { Configuration, Linter } from "tslint";
+import { getTslintOptions } from "./utils/normalizeConfig";
 
 module.exports = ({ testPath, config, globalConfig }) => {
   const start = Date.now();
-  const options = {
-    fix: false,
-    formatter: "stylish"
-  };
+  const options = getTslintOptions(config);
 
   const fileContents = fs.readFileSync(testPath, "utf8");
   const linter = new Linter(options);

--- a/src/utils/normalizeConfig.ts
+++ b/src/utils/normalizeConfig.ts
@@ -1,0 +1,24 @@
+import * as cosmiconfig from "cosmiconfig";
+import { ILinterOptions } from "tslint";
+
+const explorer = cosmiconfig("jest-runner-tslint", { sync: true });
+
+export function getTslintOptions(config) {
+  const result: ICosmiconfigOptions | undefined = explorer.load(config.rootDir);
+  if (result) {
+    return { ...BASE_CONFIG, ...result.config.cliOptions };
+  } else {
+    return BASE_CONFIG;
+  }
+}
+
+const BASE_CONFIG: ILinterOptions = {
+  fix: false,
+  formatter: "stylish"
+};
+
+interface ICosmiconfigOptions {
+  config: {
+    cliOptions: ILinterOptions;
+  };
+}


### PR DESCRIPTION
This fixes #11 by using `cosmiconfig` to configure `tslint`. Code-wise I followed how `jest-runner-eslint` did it fairly closely.

I also modified the package.json to set `fix: true` to show that it works (and just because it is nice for development as well).